### PR TITLE
Update Golang group

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ btw, for a "search engine" of telegram groups https://tgram.io seems pretty good
   - [Rust](https://t.me/rust_es)
   - [Ruby](https://t.me/Ruby_es)
   - [Ruby](https://t.me/rubymotions)
-  - [Golang](https://t.me/Go_es)
+  - [Golang](https://t.me/go_espana)
   - [Assembler](https://t.me/AsmESP)
   - [Kotlin](https://t.me/kotlinES)
   - [Angular](https://t.me/AngularWeb)


### PR DESCRIPTION
The spanish Golang group has been moved to https://t.me/go_espana since there is no admin.